### PR TITLE
[WIP] Editable Fields in Project Show

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem 'jbuilder', '~> 2.5'
 # gem 'capistrano-rails', group: :development
 gem 'devise'
 gem 'rake', '>= 12.3.0'
+gem 'best_in_place', github: 'bernat/best_in_place'
+gem 'redcarpet'
+gem 'pygments.rb'
 gem 'bootstrap', '~> 4.1.1'
 gem "font-awesome-rails"
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,10 +181,10 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redcarpet (3.4.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    redcarpet (3.4.0)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -290,4 +290,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GIT
       railties (>= 3.1)
       sass-rails
 
+GIT
+  remote: https://github.com/bernat/best_in_place.git
+  revision: 1b779e60ea912ab9c39d5c999b00c8ac44a8e535
+  specs:
+    best_in_place (3.1.1)
+      actionpack (>= 3.2)
+      railties (>= 3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -137,6 +145,8 @@ GEM
     popper_js (1.12.9)
     public_suffix (3.0.2)
     puma (3.11.4)
+    pygments.rb (1.2.1)
+      multi_json (>= 1.0.0)
     rack (2.0.5)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -174,6 +184,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    redcarpet (3.4.0)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -246,6 +257,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  best_in_place!
   better_errors
   binding_of_caller
   bootstrap (~> 4.1.1)
@@ -261,9 +273,11 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.7)
+  pygments.rb
   rails (~> 5.1.6)
   rails-controller-testing
   rake (>= 12.3.0)
+  redcarpet
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,5 +19,7 @@
 
 $(document).ready(ready);
 function ready() {
-    jQuery(".best_in_place").best_in_place();
+    try {
+        jQuery(".best_in_place").best_in_place();
+    } catch (err) {}
 }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,12 @@
 //
 //= require_tree .
 //= require jquery
+//= require best_in_place
+
 //= require rails-ujs
 //= require bootstrap
+
+$(document).ready(ready);
+function ready() {
+    jQuery(".best_in_place").best_in_place();
+}

--- a/app/assets/stylesheets/components/_variables.scss
+++ b/app/assets/stylesheets/components/_variables.scss
@@ -10,3 +10,6 @@ $input_bg: #3f3c44;
 $input_bg_highlight: #5D5964;
 $input_font_placeholder: #7D7984;
 
+
+$inline-code: #c0b095;
+$multiline-code: #a99c87;

--- a/app/assets/stylesheets/components/bestinplace.scss
+++ b/app/assets/stylesheets/components/bestinplace.scss
@@ -1,0 +1,7 @@
+@import 'variables.scss';
+
+.bip__textarea {
+  width: 100%;
+  background-color: black;
+  color: $primary_data;
+}

--- a/app/assets/stylesheets/components/button.scss
+++ b/app/assets/stylesheets/components/button.scss
@@ -39,3 +39,12 @@
 .button--background {
   background-color: $jumbotron !important;
 }
+
+.button--padding {
+  margin: 10px;
+}
+
+.button--right-align {
+  text-align: right;
+  float: right;
+}

--- a/app/assets/stylesheets/components/common.scss
+++ b/app/assets/stylesheets/components/common.scss
@@ -1,3 +1,5 @@
+@import 'variables.scss';
+
 .foreground-middle {
   z-index: 3;
 }
@@ -42,4 +44,8 @@ body {
   bottom: 0;
   width: 100%;
   height: 80px; /* Set the fixed height of the footer here */
+}
+
+hr {
+  border-top: 1px solid $multiline-code !important;
 }

--- a/app/assets/stylesheets/components/pygments.scss
+++ b/app/assets/stylesheets/components/pygments.scss
@@ -1,0 +1,122 @@
+// Some simple Github-like styles, with syntax highlighting CSS via Pygments.
+// Original content from Jeremy Seitz at [https://gist.github.com/somebox/1082608],
+// however some modifications have been made.
+
+@import 'variables.scss';
+
+pre {
+  color: $multiline-code !important;
+	background-color: $shadow;
+	padding: 10px;
+	-webkit-border-radius: 5px;
+	-moz-border-radius: 5px;
+	border-radius: 5px;
+	overflow: auto;
+}
+
+code {
+  color: $inline-code !important;
+	background-color: $shadow;
+	padding: 1px 3px;
+	-webkit-border-radius: 2px;
+	-moz-border-radius: 2px;
+	border-radius: 2px;
+}
+
+a:link, a:visited {
+	color: $primary_header;
+	text-decoration: none;
+}
+
+a:hover {
+	color: $hover !important;
+	text-decoration: none;
+}
+
+h1 {
+  font-size: 32px !important;
+	color: $primary_header !important;
+	font-weight: bold;
+}
+
+h2 {
+  font-size: 28px  !important;
+	border-bottom: 1px solid $primary_header;
+	margin-bottom: 1em;
+	color: $primary_header !important;
+}
+
+h3 {
+  font-size: 24px  !important;
+	color: $primary_header !important;
+}
+
+.hll { background-color: #002b36; color: #93a1a1 }
+.c { color: #586e75 } /* Comment */
+.err { color: #93a1a1 } /* Error */
+.g { color: #93a1a1 } /* Generic */
+.k { color: #859900 } /* Keyword */
+.l { color: #93a1a1 } /* Literal */
+.n { color: #93a1a1 } /* Name */
+.o { color: #859900 } /* Operator */
+.x { color: #cb4b16 } /* Other */
+.p { color: #93a1a1 } /* Punctuation */
+.cm { color: #586e75 } /* Comment.Multiline */
+.cp { color: #859900 } /* Comment.Preproc */
+.c1 { color: #586e75 } /* Comment.Single */
+.cs { color: #859900 } /* Comment.Special */
+.gd { color: #2aa198 } /* Generic.Deleted */
+.ge { color: #93a1a1; font-style: italic } /* Generic.Emph */
+.gr { color: #dc322f } /* Generic.Error */
+.gh { color: #cb4b16 } /* Generic.Heading */
+.gi { color: #859900 } /* Generic.Inserted */
+.go { color: #93a1a1 } /* Generic.Output */
+.gp { color: #93a1a1 } /* Generic.Prompt */
+.gs { color: #93a1a1; font-weight: bold } /* Generic.Strong */
+.gu { color: #cb4b16 } /* Generic.Subheading */
+.gt { color: #93a1a1 } /* Generic.Traceback */
+.kc { color: #cb4b16 } /* Keyword.Constant */
+.kd { color: #268bd2 } /* Keyword.Declaration */
+.kn { color: #859900 } /* Keyword.Namespace */
+.kp { color: #859900 } /* Keyword.Pseudo */
+.kr { color: #268bd2 } /* Keyword.Reserved */
+.kt { color: #dc322f } /* Keyword.Type */
+.ld { color: #93a1a1 } /* Literal.Date */
+.m { color: #2aa198 } /* Literal.Number */
+.s { color: #2aa198 } /* Literal.String */
+.na { color: #93a1a1 } /* Name.Attribute */
+.nb { color: #B58900 } /* Name.Builtin */
+.nc { color: #268bd2 } /* Name.Class */
+.no { color: #cb4b16 } /* Name.Constant */
+.nd { color: #268bd2 } /* Name.Decorator */
+.ni { color: #cb4b16 } /* Name.Entity */
+.ne { color: #cb4b16 } /* Name.Exception */
+.nf { color: #268bd2 } /* Name.Function */
+.nl { color: #93a1a1 } /* Name.Label */
+.nn { color: #93a1a1 } /* Name.Namespace */
+.nx { color: #93a1a1 } /* Name.Other */
+.py { color: #93a1a1 } /* Name.Property */
+.nt { color: #268bd2 } /* Name.Tag */
+.nv { color: #268bd2 } /* Name.Variable */
+.ow { color: #859900 } /* Operator.Word */
+.w { color: #93a1a1 } /* Text.Whitespace */
+.mf { color: #2aa198 } /* Literal.Number.Float */
+.mh { color: #2aa198 } /* Literal.Number.Hex */
+.mi { color: #2aa198 } /* Literal.Number.Integer */
+.mo { color: #2aa198 } /* Literal.Number.Oct */
+.sb { color: #586e75 } /* Literal.String.Backtick */
+.sc { color: #2aa198 } /* Literal.String.Char */
+.sd { color: #93a1a1 } /* Literal.String.Doc */
+.s2 { color: #2aa198 } /* Literal.String.Double */
+.se { color: #cb4b16 } /* Literal.String.Escape */
+.sh { color: #93a1a1 } /* Literal.String.Heredoc */
+.si { color: #2aa198 } /* Literal.String.Interpol */
+.sx { color: #2aa198 } /* Literal.String.Other */
+.sr { color: #dc322f } /* Literal.String.Regex */
+.s1 { color: #2aa198 } /* Literal.String.Single */
+.ss { color: #2aa198 } /* Literal.String.Symbol */
+.bp { color: #268bd2 } /* Name.Builtin.Pseudo */
+.vc { color: #268bd2 } /* Name.Variable.Class */
+.vg { color: #268bd2 } /* Name.Variable.Global */
+.vi { color: #268bd2 } /* Name.Variable.Instance */
+.il { color: #2aa198 } /* Literal.Number.Integer.Long */

--- a/app/assets/stylesheets/components/table.scss
+++ b/app/assets/stylesheets/components/table.scss
@@ -1,13 +1,14 @@
-.table {
-  margin: auto;
-  background-color: transparent !important;
+@import 'variables.scss';
 
+table {
+  background-color: transparent !important;
   // Required to override default Bootstrap styles
-  td {
-      border: none !important;
+  td, tr, th {
+    padding: 5px 15px 5px 15px !important;
   }
-  tr {
-      border: none !important;
+
+  td, tr {
+    border: none !important;
   }
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  helper_method :isEditable
 
   protected
 
@@ -10,5 +11,13 @@ class ApplicationController < ActionController::Base
   def refresh_page
     referrer_url = URI.parse(request.referrer) rescue URI.parse(root_path)
     redirect_to referrer_url.to_s
+  end
+
+  def isEditable
+    return current_user ? current_user.try(:isAdmin) : false
+  end
+
+  def authenticate_admin!
+    return current_user ? current_user.try(:isAdmin) : false
   end
 end

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -1,0 +1,29 @@
+class PicturesController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :update]
+  before_action :authenticate_admin!, only: [:new, :update]
+  respond_to :html, :json, :js
+
+  def new
+    project = Project.find_by(url: params[:id])
+    edit_project_path(project)
+  end
+
+  def update
+    picture = Picture.find(params[:id])
+    project = picture.project
+
+    respond_to do |format|
+      if (picture.update_attributes(picture_params))
+        format.html { redirect_to(picture, notice: 'Post was successfully updated.') }
+        format.json { respond_with_bip(picture) }
+      else
+        format.html { redirect_to :back }
+        format.json { respond_with_bip(picture) }
+      end
+    end
+  end
+
+  def picture_params
+    params.require(:picture).permit(:caption, :source)
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,6 @@
 class ProjectsController < ApplicationController
+  #respond_to :html, :json
+
   def index
     @projects = Project.all
   end
@@ -9,5 +11,25 @@ class ProjectsController < ApplicationController
       redirect_back(fallback_location: projects_path)
       return
     end
+  end
+
+  def update
+    project = Project.find_by(url: params[:id])
+
+    respond_to do |format|
+      if project.update_attributes(project_params)
+        format.html { redirect_to(project, notice: 'Post was successfully updated.') }
+        format.json { respond_with_bip(project) }
+      else
+        format.html { redirect_to :back }
+        format.json { respond_with_bip(project) }
+      end
+    end
+  end
+
+  private
+
+  def project_params
+    params.require(:project).permit(:description)
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,8 +1,21 @@
 class ProjectsController < ApplicationController
-  #respond_to :html, :json
+  before_action :authenticate_user!, only: [:create, :update, :add_picture]
+  before_action :authenticate_admin!, only: [:create, :update, :add_picture]
+  skip_before_action :verify_authenticity_token, only: [:create]
+  respond_to :html, :json, :js
 
   def index
     @projects = Project.all
+  end
+
+  def create
+    project = Project.create()
+    project.title = "New Project #{project.id}"
+    project.save
+    redirect_to edit_project_path(project)
+  end
+
+  def new
   end
 
   def show
@@ -15,9 +28,8 @@ class ProjectsController < ApplicationController
 
   def update
     project = Project.find_by(url: params[:id])
-
     respond_to do |format|
-      if project.update_attributes(project_params)
+      if (project.update_attributes(project_params))
         format.html { redirect_to(project, notice: 'Post was successfully updated.') }
         format.json { respond_with_bip(project) }
       else
@@ -27,9 +39,25 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def edit
+    if params.key?(:id)
+      @project = Project.find_by(url: params[:id])
+    end
+
+    if params.key?(:picture_carousel)
+    end
+  end
+
+  def add_picture
+    project = Project.find_by(url: params[:project_id])
+    picture = Picture.new(:project_id => project.id, :source => "www.google.com")
+    picture.save
+    redirect_to "/projects/#{project.url}/edit#Carousel-Pictures"
+  end
+
   private
 
   def project_params
-    params.require(:project).permit(:description)
+    params.require(:project).permit(:title, :description, :url, :short_description, :thumbnail, :source, :pictures, :hidden)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < Devise::SessionsController
   def create
     user = User.find_by email: params[:user][:email]
     return if user.nil?
-    return if user.activated.downcase != "true"
+    return if !user.activated
     super
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,16 @@
 module ApplicationHelper
+  def markdown(content)
+    renderer = CustomRedcarpetHTML.new(hard_wrap: true, filter_html: true, safe_links_only: true)
+    options = {
+      tables: true,
+      autolink: true,
+      no_intra_emphasis: true,
+      disable_indented_code_blocks: true,
+      fenced_code_blocks: true,
+      space_after_headers: true,
+      strikethrough: true,
+      superscript: true
+    }
+    Redcarpet::Markdown.new(renderer, options).render(content).html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   def markdown(content)
+    return if content.nil?
     renderer = CustomRedcarpetHTML.new(hard_wrap: true, filter_html: true, safe_links_only: true)
     options = {
       tables: true,

--- a/app/models/custom_redcarpet_html.rb
+++ b/app/models/custom_redcarpet_html.rb
@@ -1,0 +1,5 @@
+class CustomRedcarpetHTML < Redcarpet::Render::HTML
+  def block_code(code, language)
+    Pygments.highlight(code, lexer: language)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  def isAdmin
+    return true
+  end
 end

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -7,7 +7,7 @@
       <div class="font__header2 font__color-default-header font__shadow-small font__header--medium font--padding-bottom">
         <%= @author.description.title.html_safe %>
       </div>
-      <div class="font__data font__color-default-data font__data-justified">
+      <div class="font__data font__color-default-data font__data-left">
         <%= @author.description.data.html_safe %>
       </div>
     </div>
@@ -26,7 +26,7 @@
       <div class="font__header2 font__color-default-header font__shadow-small font__header--medium">
         <%= t('views.about.label_technical_skills') %>
       </div>
-      <div class="font__data font__color-default-data font__data-justified">
+      <div class="font__data font__color-default-data font__data-left">
         <table class="table table--large">
           <tr>
             <% @technical_skills.each do |type, skills| %>
@@ -68,7 +68,7 @@
       <div class="font__header2 font__color-default-header font__shadow-small font__header--medium">
         <%= t('views.about.label_soft_skills') %>
       </div>
-      <div class="font__data font__color-default-data font__data-justified">
+      <div class="font__data font__color-default-data font__data-left">
         <table class="table table--large">
           <tr>
             <% @soft_skills.each do |type, skills| %>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -1,0 +1,94 @@
+<%= render "partials/background" %>
+<%= render "partials/nav" %>
+
+<div class="container__box container__box-extra-small container__box-background container__box-borders">
+  <%= form_for @project do |item| %>
+    <div class="form-group container__div--centered font__data font__color-default-data">
+      <%=
+        best_in_place @project,
+        :hidden,
+        as: :checkbox,
+        collection: {false: "Click to Hide (Showing)", true: "Click to Show (Hidden)"}
+      %><br>
+    </div>
+
+    <div class="form-group container__div--centered">
+      <%= item.label "Title", class: "font__data font__color-default-data" %>
+      <%= item.text_field :title, class: "form-control input__data-centered input--background", autocomplete: "false" %><br>
+    </div>
+
+    <div class="form-group container__div--centered">
+      <%= item.label "URL", class: "font__data font__color-default-data" %>
+      <%= item.text_field :url, class: "form-control input__data-centered input--background", autocomplete: "false" %><br>
+    </div>
+
+    <div class="form-group container__div--centered">
+      <%= item.label "Source URL", class: "font__data font__color-default-data" %>
+      <%= item.text_field :source, class: "form-control input__data-centered input--background", autocomplete: "false" %><br>
+    </div>
+
+    <div class="form-group container__div--centered">
+      <%= item.label "Thumbnail URL", class: "font__data font__color-default-data" %>
+      <%= item.text_field :thumbnail, class: "form-control input__data-centered input--background", autocomplete: "false" %><br>
+    </div>
+
+    <div class="btn btn-outline-light btn--font-large button--background button__container--margin">
+      <input type="submit" value="Update" class="button__container button__container--text-small">
+    </div>
+    <br><br><br><br>
+  <% end %>
+
+  <div class="form-group container__div--centered">
+    <%= label_tag "", "Card Description",class: "font__data font__color-default-data" %>
+  </div>
+  <div class="font__data font__color-default-data">
+    <%=
+      best_in_place @project,
+      :short_description,
+      as: :textarea,
+      skip_blur: true,
+      ok_button: 'Save',
+      ok_button_class: "btn btn-outline-success button--padding",
+      cancel_button: 'Cancel',
+      cancel_button_class: "btn btn-outline-danger button--padding",
+      inner_class: "bip__textarea",
+      display_with: lambda { |t| markdown(t) }
+    %>
+  </div>
+
+  <br><br>
+  <div class="form-group container__div--centered">
+    <div data-spy="scroll" data-target="#navbar-example3" data-offset="0">
+      <%= label_tag "", "Carousel-Pictures", id: "Carousel-Pictures", class: "font__data font__color-default-data" %>
+    </div>
+  </div>
+  <% @project.try(:pictures).each do |item| %>
+    <hr>
+    <div class="form-group container__div--centered font__color-default-data">
+      <%= label_tag "", "URL: ", class: "" %>
+      <%=
+        best_in_place item,
+        :source
+      %>
+    </div>
+    <div class="font__data font__color-default-data">
+      <%=
+        best_in_place item,
+        :caption,
+        as: :textarea,
+        skip_blur: true,
+        ok_button: 'Save',
+        ok_button_class: "btn btn-outline-success button--padding",
+        cancel_button: 'Cancel',
+        cancel_button_class: "btn btn-outline-danger button--padding",
+        inner_class: "bip__textarea",
+        display_with: lambda { |t| markdown(t) }
+      %>
+    </div>
+    <%= link_to "Delete", picture_path(item), method: :delete, data: { confirm: "Are you sure?" } %>
+  <% end %>
+  <br>
+  <%= link_to "Add Another Picture to Carousel", project_add_picture_path(@project) %>
+</div>
+
+<%= render "partials/footer" %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -5,41 +5,59 @@
   <div class="container__box container__box-small">
     <div class="card-columns">
       <% @projects.each do |project| %>
-        <div class="card card--background">
-          <% if project.thumbnail.present? %>
-            <img class="card-img-top" src="<%= project.thumbnail %>" alt="Card image cap">
-          <% end %>
-          <div class="card-body">
-            <div class="font__header2 font__header--small font__color-default-header font__shadow-small font--padding-bottom">
-              <%= project.title if project.title.present? %>
+        <% if isEditable || !project.hidden %>
+          <div class="card card--background">
+            <% if project.thumbnail.present? %>
+              <img class="card-img-top" src="<%= project.thumbnail %>" alt="Card image cap">
+            <% end %>
+            <div class="card-body">
+              <div class="font__header2 font__header--small font__color-default-header font__shadow-small font--padding-bottom">
+                <%= ("#{project.title}#{project.hidden ? "<br>**CURRENTLY HIDDEN**" : ""}").html_safe if project.title.present? %>
+              </div>
+              <div class="font__data font__data--small font__color-default-data font__data-left">
+                <%= markdown(project.short_description) if project.short_description.present? %>
+              </div>
             </div>
-            <div class="font__data font__data--small font__color-default-data font__data-justified">
-              <%= project.short_description.html_safe if project.short_description.present? %>
-            </div>
-          </div>
-          <div style="padding: 5px;">
-            <form action="<%= project_path(project) %>" class="btn btn-outline-light">
-              <i class="fa fa-search"></i>
-              <input type="submit" value="Read More" class="button__container"/>
-            </form>
-          </div>
-          <% if project.source.present? %>
             <div style="padding: 5px;">
-              <form action="<%= project.source %>" target="_blank" class="btn btn-outline-light">
-                <i class="fa fa-folder"></i>
-                <input type="submit" value="Go to Source" class="button__container"/>
+              <form action="<%= project_path(project) %>" class="btn btn-outline-light">
+                <i class="fa fa-search"></i>
+                <input type="submit" value="Read More" class="button__container"/>
               </form>
             </div>
-          <% end %>
-          <% if false %>
-            <div class="card-footer">
-              <small class="text-muted">Last updated 3 mins ago</small>
-            </div>
-          <% else %>
-            <br>
-          <% end %>
-        </div>
+            <% if project.source.present? %>
+              <div style="padding: 5px;">
+                <form action="<%= project.source %>" target="_blank" class="btn btn-outline-light">
+                  <i class="fa fa-folder"></i>
+                  <input type="submit" value="Go to Source" class="button__container"/>
+                </form>
+              </div>
+            <% end %>
+            <% if isEditable %>
+              <div style="padding: 5px;">
+                <form action="<%= edit_project_path(project) %>" class="btn btn-outline-light">
+                  <i class="fa fa-edit"></i>
+                  <input type="submit" value="Edit Details" class="button__container"/>
+                </form>
+              </div>
+            <% end %>
+            <% if false %>
+              <div class="card-footer">
+                <small class="text-muted">Last updated 3 mins ago</small>
+              </div>
+            <% else %>
+              <br>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
+
+      <% if isEditable %>
+        <form action="<%= projects_path %>" method="post" class="btn btn-outline-light">
+          <i class="fa fa-plus"></i>
+          <input type="submit" value="Add Project" class="button__container"/>
+        </form>
+      <% end %>
+
     </div>
   </div>
 <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -60,10 +60,25 @@
 <div class="container__box container__box-small container__box-background container__box-borders-full container__box--no-padding">
   <div class="card-body">
     <div class="font__header2 font__header--large font__color-default-header font__shadow-small font--padding-bottom">
-      <%= @project.title if @project.title.present? %>
+      <h1>
+        <%= @project.title if @project.title.present? %>
+        <a href="#" id="activator-description" class="button--right-align">
+          <i class="fa fa-edit"></i>
+        </a>
+      </h1>
     </div>
     <div class="font__data font__color-default-data font__data-justified">
-      <%= @project.description.html_safe if @project.description.present? %>
+      <%= best_in_place @project,
+            :description,
+            as: :textarea,
+            skip_blur: true,
+            ok_button: 'Save',
+            ok_button_class: "btn btn-outline-success button--padding",
+            cancel_button: 'Cancel',
+            cancel_button_class: "btn btn-outline-danger button--padding",
+            inner_class: "bip__textarea",
+            :activator => "#activator-description",
+            display_with: lambda { |t| markdown(t) } %>
     </div>
   </div>
 </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -55,30 +55,45 @@
       <input type="submit" value="Go to Source" class="button__container"/>
     </form>
   <% end %>
+  <% if isEditable %>
+  <form action="<%= edit_project_path(@project) %>" class="btn btn-outline-light btn--font-large button--background">
+    <i class="fa fa-edit"></i>
+    <input type="submit" value="Edit Details" class="button__container"/>
+  </form>
+  <% end %>
 </div>
 
 <div class="container__box container__box-small container__box-background container__box-borders-full container__box--no-padding">
   <div class="card-body">
     <div class="font__header2 font__header--large font__color-default-header font__shadow-small font--padding-bottom">
       <h1>
-        <%= @project.title if @project.title.present? %>
-        <a href="#" id="activator-description" class="button--right-align">
-          <i class="fa fa-edit"></i>
-        </a>
+        <%=
+          best_in_place_if isEditable,
+          @project,
+          :title
+        %>
+        <% if isEditable %>
+          <a href="#" id="activator-description" class="button--right-align">
+            <i class="fa fa-edit"></i>
+          </a>
+        <% end %>
       </h1>
     </div>
-    <div class="font__data font__color-default-data font__data-justified">
-      <%= best_in_place @project,
-            :description,
-            as: :textarea,
-            skip_blur: true,
-            ok_button: 'Save',
-            ok_button_class: "btn btn-outline-success button--padding",
-            cancel_button: 'Cancel',
-            cancel_button_class: "btn btn-outline-danger button--padding",
-            inner_class: "bip__textarea",
-            :activator => "#activator-description",
-            display_with: lambda { |t| markdown(t) } %>
+    <div class="font__data font__color-default-data font__data-left">
+      <%=
+        best_in_place_if isEditable,
+        @project,
+        :description,
+        as: :textarea,
+        skip_blur: true,
+        ok_button: 'Save',
+        ok_button_class: "btn btn-outline-success button--padding",
+        cancel_button: 'Cancel',
+        cancel_button_class: "btn btn-outline-danger button--padding",
+        inner_class: "bip__textarea",
+        :activator => "#activator-description",
+        display_with: lambda { |t| markdown(t) }
+      %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
     delete "logout", to: "devise/sessions#destroy"
   end
 
-  resources :projects
+  resources :projects do
+    get "add_picture", to: "projects#add_picture"
+  end
+  resources :pictures
 
   root "pages#home"
   get "about" => "pages#about"

--- a/db/migrate/20181213113420_add_hidable_field_to_projects.rb
+++ b/db/migrate/20181213113420_add_hidable_field_to_projects.rb
@@ -1,0 +1,18 @@
+class AddHidableFieldToProjects < ActiveRecord::Migration[5.1]
+  # Sneaky change to using booleans as I forgot.
+  def up
+    add_column :projects, :hidden, :boolean, default: true
+    execute "ALTER TABLE users ALTER COLUMN activated DROP DEFAULT;"
+    execute "ALTER TABLE users ALTER COLUMN activated TYPE bool USING CASE WHEN activated='true' THEN TRUE ELSE FALSE END;"
+    execute "ALTER TABLE users ALTER COLUMN activated SET DEFAULT FALSE;"
+    execute "ALTER TABLE users ALTER COLUMN activated DROP NOT NULL;"
+  end
+
+  def down
+    remove_column :projects, :hidden
+    execute "ALTER TABLE users ALTER COLUMN activated DROP DEFAULT;"
+    execute "ALTER TABLE users ALTER COLUMN activated TYPE varchar USING CASE WHEN activated=true THEN 'true' ELSE 'false' END;"
+    execute "ALTER TABLE users ALTER COLUMN activated SET DEFAULT 'false';"
+    execute "ALTER TABLE users ALTER COLUMN activated SET NOT NULL;"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180626152719) do
+ActiveRecord::Schema.define(version: 20181213113420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20180626152719) do
     t.string "url"
     t.text "thumbnail"
     t.text "short_description"
+    t.boolean "hidden", default: true
     t.index ["url"], name: "index_projects_on_url", unique: true
   end
 
@@ -82,7 +83,7 @@ ActiveRecord::Schema.define(version: 20180626152719) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "activated", default: "false", null: false
+    t.boolean "activated", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
This PR allows users with access to edit fields when inspecting a project.

### Essential Gems
- [Best-in-place](https://github.com/bernat/best_in_place), an unobtrusive in-place editing solution.
- [Redcarpet](https://github.com/vmg/redcarpet), a ruby library for markdown processing.
- [Pygments](https://github.com/tmm1/pygments.rb), a wrapper for pythong pygments syntax highlighting.

## Layout
![image](https://user-images.githubusercontent.com/29146077/41912007-a221ee80-7991-11e8-80de-24cef4b9beaf.png)

Above the description in the top-right corner there are two buttons (if the user has editing access), the _pen_ when clicked will make the description text-area editable while the _bookmark_ will open a new tab showing a [markdown cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).

![image](https://user-images.githubusercontent.com/29146077/41912172-3db7e598-7992-11e8-9dc8-54268c5c9acd.png)

When the description has entered edit-mode the background turns all black, with two buttons appearing near the bottom allowing the user to `Save` or `Cancel` any changes made.

![image](https://user-images.githubusercontent.com/29146077/41912275-94899a60-7992-11e8-8967-5f9895bc8a1c.png)
![image](https://user-images.githubusercontent.com/29146077/41912277-96887c46-7992-11e8-83bb-eacfa634f42c.png)
![image](https://user-images.githubusercontent.com/29146077/41912283-99ab93b8-7992-11e8-9e0b-b09238289bc9.png)

As seen above, most of the `markdown` one would be familiar with from Github is present here as well.


